### PR TITLE
Stringify keys using another instance of Hash.

### DIFF
--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -84,13 +84,13 @@ module OmniAuth
 
     def add_mock(provider, mock = {})
       # Stringify keys recursively one level.
-      mock.keys.each do |key|
-        mock[key.to_s] = mock.delete(key)
-      end
-      mock.each_pair do |_key, val|
+      new_mock = {}
+      mock.keys.each { |key| new_mock[key.to_s] = mock[key] }
+      new_mock.each_pair do |_key, val|
         if val.is_a? Hash
+          new_val = {}
           val.keys.each do |subkey|
-            val[subkey.to_s] = val.delete(subkey)
+            new_val[subkey.to_s] = val[subkey]
           end
         else
           next
@@ -98,7 +98,7 @@ module OmniAuth
       end
 
       # Merge with the default mock and ensure provider is correct.
-      mock = mock_auth[:default].dup.merge(mock)
+      mock = mock_auth[:default].dup.merge(new_mock)
       mock['provider'] = provider.to_s
 
       # Add it to the mocks.

--- a/spec/omniauth_spec.rb
+++ b/spec/omniauth_spec.rb
@@ -110,6 +110,19 @@ describe OmniAuth do
         end
       end
     end
+
+    specify '.add_mock does not change the hash inputed' do
+      @hash_inputed = {
+        :uid => '12345',
+        :info => {:name => 'Joe', :email => 'joe@example.com'},
+      }
+
+      OmniAuth.config.add_mock(:facebook, @hash_inputed)
+
+      expect(@hash_inputed[:uid]).to be == '12345'
+      expect(@hash_inputed[:info][:name]).to be == 'Joe'
+      expect(@hash_inputed[:info][:email]).to be == 'joe@example.com'
+    end
   end
 
   describe '.logger' do


### PR DESCRIPTION
Creating another instance of Hash when stringifying the keys to avoid change the hash inputed.