### PR TITLE
Add the config.session_key to override 'rack.session'

### DIFF
--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -43,6 +43,7 @@ module OmniAuth
         :logger => default_logger,
         :allowed_request_methods => [:get, :post],
         :mock_auth => {:default => AuthHash.new('provider' => 'default', 'uid' => '1234', 'info' => {'name' => 'Example User'})},
+        :session_key => 'rack.session',
       }
     end
 
@@ -116,7 +117,7 @@ module OmniAuth
     end
 
     attr_writer :on_failure, :before_callback_phase, :before_options_phase, :before_request_phase
-    attr_accessor :failure_raise_out_environments, :path_prefix, :allowed_request_methods, :form_css, :test_mode, :mock_auth, :full_host, :camelizations, :logger
+    attr_accessor :failure_raise_out_environments, :path_prefix, :allowed_request_methods, :form_css, :test_mode, :mock_auth, :full_host, :camelizations, :logger, :session_key
   end
 
   def self.config

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -170,7 +170,7 @@ module OmniAuth
     #
     # @param env [Hash] The Rack environment.
     def call!(env) # rubocop:disable CyclomaticComplexity, PerceivedComplexity
-      unless env['rack.session']
+      unless env[OmniAuth.config.session_key]
         error = OmniAuth::NoSessionError.new('You must provide a session to use OmniAuth.')
         fail(error)
       end
@@ -208,9 +208,9 @@ module OmniAuth
         call_app!
       else
         if request.params['origin']
-          env['rack.session']['omniauth.origin'] = request.params['origin']
+          session['omniauth.origin'] = request.params['origin']
         elsif env['HTTP_REFERER'] && !env['HTTP_REFERER'].match(/#{request_path}$/)
-          env['rack.session']['omniauth.origin'] = env['HTTP_REFERER']
+          session['omniauth.origin'] = env['HTTP_REFERER']
         end
         request_phase
       end
@@ -268,9 +268,9 @@ module OmniAuth
       session['omniauth.params'] = request.params
       OmniAuth.config.before_request_phase.call(env) if OmniAuth.config.before_request_phase
       if request.params['origin']
-        @env['rack.session']['omniauth.origin'] = request.params['origin']
+        session['omniauth.origin'] = request.params['origin']
       elsif env['HTTP_REFERER'] && !env['HTTP_REFERER'].match(/#{request_path}$/)
-        @env['rack.session']['omniauth.origin'] = env['HTTP_REFERER']
+        session['omniauth.origin'] = env['HTTP_REFERER']
       end
 
       redirect(callback_url)
@@ -437,7 +437,7 @@ module OmniAuth
     end
 
     def session
-      @env['rack.session']
+      @env[OmniAuth.config.session_key]
     end
 
     def request

--- a/lib/omniauth/test/phony_session.rb
+++ b/lib/omniauth/test/phony_session.rb
@@ -6,8 +6,8 @@ module OmniAuth
       end
 
       def call(env)
-        @session ||= (env['rack.session'] || {})
-        env['rack.session'] = @session
+        @session ||= (env[OmniAuth.config.session_key] || {})
+        env[OmniAuth.config.session_key] = @session
         @app.call(env)
       end
     end

--- a/lib/omniauth/test/strategy_test_case.rb
+++ b/lib/omniauth/test/strategy_test_case.rb
@@ -32,7 +32,7 @@ module OmniAuth
       end
 
       def session
-        last_request.env['rack.session']
+        last_request.env[OmniAuth.config.session_key]
       end
 
       def strategy


### PR DESCRIPTION
Hello,

This PR allows this kind of configuration:

``` ruby
OmniAuth.config.session_key = "rack.production.session"
```

Maybe some of you will find it usefull as I do ^^