### PR TITLE
Stop mutating given hash in #add_mock

### DIFF
--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -82,19 +82,15 @@ module OmniAuth
       end
     end
 
-    def add_mock(provider, mock = {})
-      # Stringify keys recursively one level.
-      mock.keys.each do |key|
-        mock[key.to_s] = mock.delete(key)
-      end
-      mock.each_pair do |_key, val|
-        if val.is_a? Hash
-          val.keys.each do |subkey|
-            val[subkey.to_s] = val.delete(subkey)
-          end
-        else
-          next
-        end
+    def add_mock(provider, original = {})
+      # Create key-stringified new hash from given auth hash
+      mock = {}
+      original.each_pair do |key, val|
+        mock[key.to_s] = if val.is_a? Hash
+                           Hash[val.each_pair{ |k,v| [k.to_s, v] }]
+                         else
+                           val
+                         end
       end
 
       # Merge with the default mock and ensure provider is correct.

--- a/lib/omniauth.rb
+++ b/lib/omniauth.rb
@@ -87,7 +87,7 @@ module OmniAuth
       mock = {}
       original.each_pair do |key, val|
         mock[key.to_s] = if val.is_a? Hash
-                           Hash[val.each_pair{ |k,v| [k.to_s, v] }]
+                           Hash[val.each_pair { |k, v| [k.to_s, v] }]
                          else
                            val
                          end

--- a/spec/omniauth_spec.rb
+++ b/spec/omniauth_spec.rb
@@ -90,7 +90,7 @@ describe OmniAuth do
 
     describe 'mock auth' do
       before do
-        @auth_hash = { :uid => '12345', :info => {:name => 'Joe', :email => 'joe@example.com'} }
+        @auth_hash = {:uid => '12345', :info => {:name => 'Joe', :email => 'joe@example.com'}}
         @original_auth_hash = Marshal.load(Marshal.dump(@auth_hash))
 
         OmniAuth.config.add_mock(:facebook, @auth_hash)
@@ -113,7 +113,7 @@ describe OmniAuth do
         end
       end
       it 'does not mutate given auth hash' do
-        OmniAuth.configure do |config|
+        OmniAuth.configure do
           expect(@auth_hash).to eq @original_auth_hash
         end
       end

--- a/spec/omniauth_spec.rb
+++ b/spec/omniauth_spec.rb
@@ -90,7 +90,10 @@ describe OmniAuth do
 
     describe 'mock auth' do
       before do
-        OmniAuth.config.add_mock(:facebook, :uid => '12345', :info => {:name => 'Joe', :email => 'joe@example.com'})
+        @auth_hash = { :uid => '12345', :info => {:name => 'Joe', :email => 'joe@example.com'} }
+        @original_auth_hash = Marshal.load(Marshal.dump(@auth_hash))
+
+        OmniAuth.config.add_mock(:facebook, @auth_hash)
       end
       it 'default is AuthHash' do
         OmniAuth.configure do |config|
@@ -107,6 +110,11 @@ describe OmniAuth do
           expect(config.mock_auth[:facebook].uid).to eq('12345')
           expect(config.mock_auth[:facebook].info.name).to eq('Joe')
           expect(config.mock_auth[:facebook].info.email).to eq('joe@example.com')
+        end
+      end
+      it 'does not mutate given auth hash' do
+        OmniAuth.configure do |config|
+          expect(@auth_hash).to eq @original_auth_hash
         end
       end
     end


### PR DESCRIPTION
`#add_mock` was stringifying original auth hash.