### PR TITLE
Duplicate options when a strategy is duplicated

### DIFF
--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -479,14 +479,15 @@ module OmniAuth
       OmniAuth.config.on_failure.call(env)
     end
 
+    def dup
+      super.tap do
+        @options = @options.dup
+      end
+    end
+
     class Options < Hashie::Mash; end
 
   protected
-
-    def initialize_copy(orig)
-      super
-      @options = @options.dup
-    end
 
     def merge_stack(stack)
       stack.inject({}) do |a, e|

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -483,6 +483,11 @@ module OmniAuth
 
   protected
 
+    def initialize_copy(orig)
+      super
+      @options = @options.dup
+    end
+
     def merge_stack(stack)
       stack.inject({}) do |a, e|
         a.merge!(e)

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -31,7 +31,7 @@ class ExampleStrategy
   option :name, 'test'
 
   def call(env)
-    self.call!(env)
+    options[:dup] ? super : self.call!(env)
   end
 
   def initialize(*args, &block)
@@ -40,6 +40,7 @@ class ExampleStrategy
   end
 
   def request_phase
+    options[:mutate_on_request].call(options) if options[:mutate_on_request]
     @fail = fail!(options[:failure]) if options[:failure]
     @last_env = env
     return @fail if @fail
@@ -47,6 +48,7 @@ class ExampleStrategy
   end
 
   def callback_phase
+    options[:mutate_on_callback].call(options) if options[:mutate_on_callback]
     @fail = fail!(options[:failure]) if options[:failure]
     @last_env = env
     return @fail if @fail

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -545,24 +545,24 @@ describe OmniAuth::Strategy do
 
     context 'options mutation' do
       before do
-        @options = { :dup => true }
+        @options = {:dup => true}
       end
 
       context 'in request phase' do
         it 'does not affect original options' do
-          @options.merge!({
+          @options.merge!(
             :test_option => true,
-            :mutate_on_request => proc { |options| options.delete(:test_option) }
-          })
+            :mutate_on_request => proc { |options| options.delete(:test_option) },
+          )
           expect { strategy.call(make_env) }.to raise_error('Request Phase')
           expect(strategy.options).to have_key(:test_option)
         end
 
         it 'does not affect deep options' do
-          @options.merge!({
-            :deep_option => { :test_option => true },
-            :mutate_on_request => proc { |options| options[:deep_option].delete(:test_option) }
-          })
+          @options.merge!(
+            :deep_option => {:test_option => true},
+            :mutate_on_request => proc { |options| options[:deep_option].delete(:test_option) },
+          )
           expect { strategy.call(make_env) }.to raise_error('Request Phase')
           expect(strategy.options[:deep_option]).to have_key(:test_option)
         end
@@ -570,19 +570,19 @@ describe OmniAuth::Strategy do
 
       context 'in callback phase' do
         it 'does not affect original options' do
-          @options.merge!({
+          @options.merge!(
             :test_option => true,
-            :mutate_on_callback => proc { |options| options.delete(:test_option) }
-          })
+            :mutate_on_callback => proc { |options| options.delete(:test_option) },
+          )
           expect { strategy.call(make_env('/auth/test/callback', 'REQUEST_METHOD' => 'POST')) }.to raise_error('Callback Phase')
           expect(strategy.options).to have_key(:test_option)
         end
 
         it 'does not affect deep options' do
-          @options.merge!({
-            :deep_option => { :test_option => true },
-            :mutate_on_callback => proc { |options| options[:deep_option].delete(:test_option) }
-          })
+          @options.merge!(
+            :deep_option => {:test_option => true},
+            :mutate_on_callback => proc { |options| options[:deep_option].delete(:test_option) },
+          )
           expect { strategy.call(make_env('/auth/test/callback', 'REQUEST_METHOD' => 'POST')) }.to raise_error('Callback Phase')
           expect(strategy.options[:deep_option]).to have_key(:test_option)
         end

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -543,6 +543,52 @@ describe OmniAuth::Strategy do
       end
     end
 
+    context 'options mutation' do
+      before do
+        @options = { :dup => true }
+      end
+
+      context 'in request phase' do
+        it 'does not affect original options' do
+          @options.merge!({
+            :test_option => true,
+            :mutate_on_request => proc { |options| options.delete(:test_option) }
+          })
+          expect { strategy.call(make_env) }.to raise_error('Request Phase')
+          expect(strategy.options).to have_key(:test_option)
+        end
+
+        it 'does not affect deep options' do
+          @options.merge!({
+            :deep_option => { :test_option => true },
+            :mutate_on_request => proc { |options| options[:deep_option].delete(:test_option) }
+          })
+          expect { strategy.call(make_env) }.to raise_error('Request Phase')
+          expect(strategy.options[:deep_option]).to have_key(:test_option)
+        end
+      end
+
+      context 'in callback phase' do
+        it 'does not affect original options' do
+          @options.merge!({
+            :test_option => true,
+            :mutate_on_callback => proc { |options| options.delete(:test_option) }
+          })
+          expect { strategy.call(make_env('/auth/test/callback', 'REQUEST_METHOD' => 'POST')) }.to raise_error('Callback Phase')
+          expect(strategy.options).to have_key(:test_option)
+        end
+
+        it 'does not affect deep options' do
+          @options.merge!({
+            :deep_option => { :test_option => true },
+            :mutate_on_callback => proc { |options| options[:deep_option].delete(:test_option) }
+          })
+          expect { strategy.call(make_env('/auth/test/callback', 'REQUEST_METHOD' => 'POST')) }.to raise_error('Callback Phase')
+          expect(strategy.options[:deep_option]).to have_key(:test_option)
+        end
+      end
+    end
+
     context 'test mode' do
       let(:app) do
         # In test mode, the underlying app shouldn't be called on request phase.

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -552,7 +552,7 @@ describe OmniAuth::Strategy do
         it 'does not affect original options' do
           @options.merge!(
             :test_option => true,
-            :mutate_on_request => proc { |options| options.delete(:test_option) },
+            :mutate_on_request => proc { |options| options.delete(:test_option) }
           )
           expect { strategy.call(make_env) }.to raise_error('Request Phase')
           expect(strategy.options).to have_key(:test_option)
@@ -561,7 +561,7 @@ describe OmniAuth::Strategy do
         it 'does not affect deep options' do
           @options.merge!(
             :deep_option => {:test_option => true},
-            :mutate_on_request => proc { |options| options[:deep_option].delete(:test_option) },
+            :mutate_on_request => proc { |options| options[:deep_option].delete(:test_option) }
           )
           expect { strategy.call(make_env) }.to raise_error('Request Phase')
           expect(strategy.options[:deep_option]).to have_key(:test_option)
@@ -572,7 +572,7 @@ describe OmniAuth::Strategy do
         it 'does not affect original options' do
           @options.merge!(
             :test_option => true,
-            :mutate_on_callback => proc { |options| options.delete(:test_option) },
+            :mutate_on_callback => proc { |options| options.delete(:test_option) }
           )
           expect { strategy.call(make_env('/auth/test/callback', 'REQUEST_METHOD' => 'POST')) }.to raise_error('Callback Phase')
           expect(strategy.options).to have_key(:test_option)
@@ -581,7 +581,7 @@ describe OmniAuth::Strategy do
         it 'does not affect deep options' do
           @options.merge!(
             :deep_option => {:test_option => true},
-            :mutate_on_callback => proc { |options| options[:deep_option].delete(:test_option) },
+            :mutate_on_callback => proc { |options| options[:deep_option].delete(:test_option) }
           )
           expect { strategy.call(make_env('/auth/test/callback', 'REQUEST_METHOD' => 'POST')) }.to raise_error('Callback Phase')
           expect(strategy.options[:deep_option]).to have_key(:test_option)


### PR DESCRIPTION
This PR adds an implementation of `initialize_copy` to `OmniAuth::Strategy` that calls `@options.dup`. Since `@options` is a `Hashie::Mash` instance (:see_no_evil:), calling `dup` does a deep copy.

This addresses the issue that I reported in #823 and https://github.com/PracticallyGreen/omniauth-saml/issues/54.