### PR TITLE
Hashie >= 2.1 doesn't support Ruby 1.8 (CI build fix! 🍣🍣🍣=͟͟͞͞)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :test do
   gem 'coveralls'
   gem 'json', '>= 1.8.1', :platforms => [:jruby, :ruby_18, :ruby_19]
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
+  gem 'hashie', '~> 2.0.5', :platforms => [:ruby_18, :jruby_18]
   gem 'rack-test'
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]
   gem 'rspec', '~> 3.0'

--- a/Gemfile.rack-1.3.x
+++ b/Gemfile.rack-1.3.x
@@ -9,6 +9,7 @@ group :test do
   gem 'coveralls', :require => false
   gem 'json', '>= 1.8.1', :platforms => [:jruby, :rbx, :ruby_18, :ruby_19]
   gem 'mime-types', '~> 1.25', :platforms => [:jruby, :ruby_18]
+  gem 'hashie', '~> 2.0.5', :platforms => [:ruby_18, :jruby_18]
   gem 'rack-test'
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby, :ruby_18]
   gem 'rspec', '>= 2.14'

--- a/lib/omniauth/auth_hash.rb
+++ b/lib/omniauth/auth_hash.rb
@@ -40,7 +40,7 @@ module OmniAuth
       end
 
       def name?
-        !!name # rubocop:disable DoubleNegation
+        !!name
       end
       alias_method :valid?, :name?
 

--- a/lib/omniauth/form.rb
+++ b/lib/omniauth/form.rb
@@ -1,5 +1,5 @@
 module OmniAuth
-  class Form # rubocop:disable ClassLength
+  class Form
     DEFAULT_CSS = File.read(File.expand_path('../form.css', __FILE__))
 
     attr_accessor :options

--- a/lib/omniauth/strategies/developer.rb
+++ b/lib/omniauth/strategies/developer.rb
@@ -37,7 +37,7 @@ module OmniAuth
       def request_phase
         form = OmniAuth::Form.new(:title => 'User Info', :url => callback_path)
         options.fields.each do |field|
-          form.text_field field.to_s.capitalize.gsub('_', ' '), field.to_s
+          form.text_field field.to_s.capitalize.tr('_', ' '), field.to_s
         end
         form.button 'Sign In'
         form.to_response

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -607,7 +607,7 @@ describe OmniAuth::Strategy do
 
       it 'responds with a provider-specific hash if one is set' do
         OmniAuth.config.mock_auth[:test] = {
-          'uid' => 'abc',
+          'uid' => 'abc'
         }
 
         strategy.call make_env('/auth/test/callback')


### PR DESCRIPTION
We see so many CI failures against ruby 1.8.7 in the PRs on this repo, and due to which, I suppose, this repo seems somewhat inactive recently.

This problem is actually totally unrelated to changesets in those PRs, but it's because we're bundling Hashie 3.x that doesn't support Ruby 1.8.

After merging this, we would be able to merge other good ones such as #820, #828, #829, etcetc.

see: https://github.com/intridea/hashie/blob/master/CHANGELOG.md#210-462014