### PR TITLE
Modermized (2.2.4, 2.3.0, 2016) and fixed Rubocop errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,13 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3.0
   - jruby-head
   - rbx-2
   - ruby-head
 matrix:
   include:
-    - rvm: 2.2.2
+    - rvm: 2.2.4
       gemfile: Gemfile.rack-master
   allow_failures:
     - rvm: jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'rack-test'
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby_18, :ruby_18]
   gem 'rspec', '~> 3.0'
-  gem 'rubocop', '>= 0.25', :platforms => [:ruby_19, :ruby_20, :ruby_21, :ruby_22]
+  gem 'rubocop', '>= 0.25', :platforms => [:ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23]
   gem 'simplecov', '>= 0.9'
 end
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ your first stop if you are wondering about a more in-depth look at
 OmniAuth, how it works, and how to use it.
 
 ## Supported Ruby Versions
-OmniAuth is tested under 1.8.7, 1.9.3, 2.0.0, 2.1.0, JRuby, and Rubinius.
+OmniAuth is tested under 1.8.7, 1.9.3, 2.0.0, 2.1.0, 2.2, 2.3, JRuby, and Rubinius.
 
 ## Versioning
 This library aims to adhere to [Semantic Versioning 2.0.0][semver]. Violations

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Constraint][pvc] with two digits of precision. For example:
 [pvc]: http://docs.rubygems.org/read/chapter/16#page74
 
 ## License
-Copyright (c) 2010-2013 Michael Bleigh and Intridea, Inc. See [LICENSE][] for
+Copyright (c) 2010-2016 Michael Bleigh and Intridea, Inc. See [LICENSE][] for
 details.
 
 [license]: LICENSE.md

--- a/lib/omniauth/auth_hash.rb
+++ b/lib/omniauth/auth_hash.rb
@@ -42,7 +42,7 @@ module OmniAuth
       def name?
         !!name
       end
-      alias_method :valid?, :name?
+      alias valid? name?
 
       def to_hash
         hash = super

--- a/lib/omniauth/builder.rb
+++ b/lib/omniauth/builder.rb
@@ -49,7 +49,7 @@ module OmniAuth
         middleware = klass
       else
         begin
-          middleware = OmniAuth::Strategies.const_get("#{OmniAuth::Utils.camelize(klass.to_s)}")
+          middleware = OmniAuth::Strategies.const_get(OmniAuth::Utils.camelize(klass.to_s).to_s)
         rescue NameError
           raise(LoadError.new("Could not find matching strategy for #{klass.inspect}. You may need to install an additional gem (such as omniauth-#{klass})."))
         end

--- a/lib/omniauth/strategy.rb
+++ b/lib/omniauth/strategy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hashie/mash'
 
 module OmniAuth

--- a/lib/omniauth/version.rb
+++ b/lib/omniauth/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module OmniAuth
-  VERSION = '1.3.1'
+  VERSION = '1.3.1'.freeze
 end

--- a/omniauth.gemspec
+++ b/omniauth.gemspec
@@ -4,9 +4,9 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'omniauth/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'hashie', ['>= 1.2', '< 4']
-  spec.add_dependency 'rack', ['>= 1.0', '< 3']
-  spec.add_development_dependency 'bundler', '~> 1.0'
+  spec.add_dependency 'hashie'
+  spec.add_dependency 'rack'
+  spec.add_development_dependency 'bundler'
   spec.authors       = ['Michael Bleigh', 'Erik Michaels-Ober', 'Tom Milewski']
   spec.description   = 'A generalized Rack framework for multiple-provider authentication.'
   spec.email         = ['michael@intridea.com', 'sferik@gmail.com', 'tmilewski@gmail.com']

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -32,7 +32,7 @@ class ExampleStrategy
   option :name, 'test'
 
   def call(env)
-    options[:dup] ? super : self.call!(env)
+    options[:dup] ? super : call!(env)
   end
 
   def initialize(*args, &block)

--- a/spec/omniauth/failure_endpoint_spec.rb
+++ b/spec/omniauth/failure_endpoint_spec.rb
@@ -50,7 +50,7 @@ describe OmniAuth::FailureEndpoint do
     end
 
     it 'includes the origin (escaped) if one is provided' do
-      env.merge! 'omniauth.origin' => '/origin-example'
+      env['omniauth.origin'] = '/origin-example'
       _, head, = *subject.call(env)
       expect(head['Location']).to be_include('&origin=%2Forigin-example')
     end

--- a/spec/omniauth/strategy_spec.rb
+++ b/spec/omniauth/strategy_spec.rb
@@ -155,7 +155,7 @@ describe OmniAuth::Strategy do
   end
 
   %w(request_phase).each do |abstract_method|
-    context "#{abstract_method}" do
+    context abstract_method.to_s do
       it 'raises a NotImplementedError' do
         strat = Class.new
         strat.send :include, OmniAuth::Strategy
@@ -550,19 +550,19 @@ describe OmniAuth::Strategy do
 
       context 'in request phase' do
         it 'does not affect original options' do
-          @options.merge!(
-            :test_option => true,
-            :mutate_on_request => proc { |options| options.delete(:test_option) }
-          )
+          @options[:test_option] = true
+          @options[:mutate_on_request] = proc do |options|
+            options.delete(:test_option)
+          end
           expect { strategy.call(make_env) }.to raise_error('Request Phase')
           expect(strategy.options).to have_key(:test_option)
         end
 
         it 'does not affect deep options' do
-          @options.merge!(
-            :deep_option => {:test_option => true},
-            :mutate_on_request => proc { |options| options[:deep_option].delete(:test_option) }
-          )
+          @options[:deep_option] = {:test_option => true}
+          @options[:mutate_on_request] = proc do |options|
+            options[:deep_option].delete(:test_option)
+          end
           expect { strategy.call(make_env) }.to raise_error('Request Phase')
           expect(strategy.options[:deep_option]).to have_key(:test_option)
         end
@@ -570,19 +570,19 @@ describe OmniAuth::Strategy do
 
       context 'in callback phase' do
         it 'does not affect original options' do
-          @options.merge!(
-            :test_option => true,
-            :mutate_on_callback => proc { |options| options.delete(:test_option) }
-          )
+          @options[:test_option] = true
+          @options[:mutate_on_callback] = proc do |options|
+            options.delete(:test_option)
+          end
           expect { strategy.call(make_env('/auth/test/callback', 'REQUEST_METHOD' => 'POST')) }.to raise_error('Callback Phase')
           expect(strategy.options).to have_key(:test_option)
         end
 
         it 'does not affect deep options' do
-          @options.merge!(
-            :deep_option => {:test_option => true},
-            :mutate_on_callback => proc { |options| options[:deep_option].delete(:test_option) }
-          )
+          @options[:deep_option] = {:test_option => true}
+          @options[:mutate_on_callback] = proc do |options|
+            options[:deep_option].delete(:test_option)
+          end
           expect { strategy.call(make_env('/auth/test/callback', 'REQUEST_METHOD' => 'POST')) }.to raise_error('Callback Phase')
           expect(strategy.options[:deep_option]).to have_key(:test_option)
         end


### PR DESCRIPTION
 * Now supports Ruby 2.3.0.
   * In .travis.file I changed 2.2.2 to 2.2.4 and added 2.3.0.
 * Fixed Rubocop errors.
 * Changed Copyright to 2016. 